### PR TITLE
Actualizar Hint para que netbeans no intente compilar con JDK 7

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -14,6 +14,6 @@ That way multiple projects can share the same settings (useful for formatting ru
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
         <org-netbeans-modules-javascript2-requirejs.enabled>true</org-netbeans-modules-javascript2-requirejs.enabled>
-        <netbeans.hint.jdkPlatform>JDK_1.7</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>


### PR DESCRIPTION
Debido a como  estaba el hint, al abrir el proyecto con Netbeans, intenta compilar con JDK 7, lo cual da error (este hint tiene mayor prioridad que lo especificado en pom.xml).
Probablemente no a todo mundo la haya dado problema antes porque de no encontrar un JDK 7 instalado en el equipo se va con el default, pero creo que lo mejor es especificarlo explicitamente.